### PR TITLE
use strict checking and fix strict violation

### DIFF
--- a/palindrome-products/example.js
+++ b/palindrome-products/example.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = function Palindromes(options) {
-
   this.maxFactor = options.maxFactor;
   this.minFactor = options.minFactor || 1;
 

--- a/palindrome-products/palindrome-products_test.spec.js
+++ b/palindrome-products/palindrome-products_test.spec.js
@@ -1,3 +1,4 @@
+'use strict';
 var Palindromes = require('./palindrome-products');
 
 describe("Palindrome", function() {
@@ -5,14 +6,16 @@ describe("Palindrome", function() {
   it("largest palindrome from single digit factors", function() {
     var palindromes = new Palindromes({maxFactor: 9});
     palindromes.generate();
-    largest = palindromes.largest();
+
+    var largest = palindromes.largest();
     expect(largest.value).toEqual(9);
-    expect([[[3, 3], [1, 9]], [[1, 9], [3, 3]]]).toContain(largest.factors)
+    expect([[[3, 3], [1, 9]], [[1, 9], [3, 3]]]).toContain(largest.factors);
   });
 
   xit("largets palindrome from double digit factors", function() {
     var palindromes = new Palindromes({ maxFactor: 99, minFactor: 10 });
     palindromes.generate();
+
     var largest = palindromes.largest();
     expect(largest.value).toEqual(9009);
     expect(largest.factors).toEqual([[91, 99]]);
@@ -21,6 +24,7 @@ describe("Palindrome", function() {
   xit("smallest palindrome from double digit factors", function() {
     var palindromes = new Palindromes({ maxFactor: 99, minFactor: 10 });
     palindromes.generate();
+
     var smallest = palindromes.smallest();
     expect(smallest.value).toEqual(121);
     expect(smallest.factors).toEqual([[11, 11]]);
@@ -29,6 +33,7 @@ describe("Palindrome", function() {
   xit("largest palindrome from triple digit factors", function() {
     var palindromes = new Palindromes({ maxFactor: 999, minFactor: 100 });
     palindromes.generate();
+
     var largest = palindromes.largest();
     expect(largest.value).toEqual(906609);
     expect(largest.factors).toEqual([[913, 993]]);
@@ -37,8 +42,10 @@ describe("Palindrome", function() {
   xit("smallest palindrome from triple digit factors", function() {
     var palindromes = new Palindromes({ maxFactor: 999, minFactor: 100 });
     palindromes.generate();
+
     var smallest = palindromes.smallest();
     expect(smallest.value).toEqual(10201);
     expect(smallest.factors).toEqual([[101, 101]]);
   });
+
 });


### PR DESCRIPTION
I noticed a missing `var` statement which implicitly leaks a global variable. This sort of error is flagged by the VM if `use strict` is in play.
- add `use strict`
- fix violation
- fix missing semicolon
