### PR TITLE
WIP: This fails on running tests for: accumulate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # assignments
 ASSIGNMENT ?= ""
-IGNOREDIRS := "^(.git|node_modules|bin)$$"
+IGNOREDIRS := "^(\.git|bin|node_modules)$$"
 ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | sort | grep -Ev $(IGNOREDIRS))
 
 # output directories


### PR DESCRIPTION
I'm screwing up the `Makefile`. @wilmoore would you mind taking a look at this?

``` bash
# ...
running tests for: gigasecond
.

Finished in 0.004 seconds
1 test, 1 assertion, 0 failures, 0 skipped

running tests for: git
gitcp: git/git_test.spec.js: No such file or directory
make[1]: *** [test-assignment] Error 1
make: *** [test] Error 1
```
