### PR TITLE
Removing "!" from calm test.

### DIFF
--- a/bob/bob_test.spec.js
+++ b/bob/bob_test.spec.js
@@ -59,7 +59,7 @@ describe("Bob", function() {
   });
 
   xit("calmly speaking about umlauts", function() {
-    var result = bob.hey("\xdcML\xe4\xdcTS!");
+    var result = bob.hey("\xdcML\xe4\xdcTS");
     expect(result).toEqual('Whatever.');
   });
 


### PR DESCRIPTION
I believe the "calmly speaking about umlauts" test on the "bob" exercise has an unwanted trailing "!". The exclamation point makes it identical to the previous test, "shouting with umlauts".
