### PR TITLE
replacing escape code for lowercase umlaut with the right one

### DIFF
--- a/bob/bob_test.spec.js
+++ b/bob/bob_test.spec.js
@@ -59,7 +59,7 @@ describe("Bob", function() {
   });
 
   xit("calmly speaking about umlauts", function() {
-    var result = bob.hey("\xdcML\xe4\xdcTS");
+    var result = bob.hey("\xfcML\xe4\xdcTS");
     expect(result).toEqual('Whatever.');
   });
 


### PR DESCRIPTION
After working through the js tests I realized that using [this reference](http://www.javascripter.net/faq/accentedcharacters.htm) it seems like there was a mistake in the spec.

`ü \xFC    &#252;  &uuml;  %FC %C3%BC  latin small letter u with diaeresis`
