### PR TITLE
Fix Robot Name test falsely passes #56

### DIFF
--- a/robot-name/robot-name_test.spec.js
+++ b/robot-name/robot-name_test.spec.js
@@ -3,7 +3,7 @@ var Robot = require('./robot-name');
 describe("Robot", function() {
   it("has a name", function() {
     var robot = new Robot();
-    expect(robot.name).toMatch(/[A-Z]{2}\d{3}/);
+    expect(robot.name).toMatch(/^[A-Z]{2}\d{3}$/);
   });
 
   xit("name is the same each time", function() {


### PR DESCRIPTION
This should fix #56, it's a more specific regular expression than \w.
