### PR TITLE
throw when illegal

### DIFF
--- a/triangle/example.js
+++ b/triangle/example.js
@@ -7,7 +7,7 @@ function Triangle(a,b,c) {
     var name = "scalene";
 
     if (this.isIllegal()) {
-      name = "illegal";
+      throw new TypeError('illegal');
     } else if (this.isEquilateral()) {
       name = "equilateral";
     } else if (this.isIsosceles()) {

--- a/triangle/triangle_test.spec.js
+++ b/triangle/triangle_test.spec.js
@@ -7,74 +7,74 @@ describe("Triangle", function() {
     expect(triangle.kind()).toEqual("equilateral");
   });
 
-  xit("larger equilateral triangles also have equal sides", function() {
+  it("larger equilateral triangles also have equal sides", function() {
     var triangle = new Triangle(10,10,10);
     expect(triangle.kind()).toEqual("equilateral");
   });
 
-  xit("isosceles triangles have last two sides equal", function() {
+  it("isosceles triangles have last two sides equal", function() {
     var triangle = new Triangle(3,4,4);
     expect(triangle.kind()).toEqual("isosceles");
   });
 
-  xit("isosceles trianges have first and last sides equal", function() {
+  it("isosceles trianges have first and last sides equal", function() {
     var triangle = new Triangle(4,3,4);
     expect(triangle.kind()).toEqual("isosceles");
   });
 
-  xit("isosceles triangles have two first sides equal", function() {
+  it("isosceles triangles have two first sides equal", function() {
     var triangle = new Triangle(4,4,3);
     expect(triangle.kind()).toEqual("isosceles");
   });
 
-  xit("isosceles triangles have in fact exactly two sides equal", function() {
+  it("isosceles triangles have in fact exactly two sides equal", function() {
     var triangle = new Triangle(10,10,2);
     expect(triangle.kind()).toEqual("isosceles");
   });
 
-  xit("scalene triangles have no equal sides", function() {
+  it("scalene triangles have no equal sides", function() {
     var triangle = new Triangle(3,4,5);
     expect(triangle.kind()).toEqual("scalene");
   });
 
-  xit("scalene triangles have no equal sides at a larger scale too", function() {
+  it("scalene triangles have no equal sides at a larger scale too", function() {
     var triangle = new Triangle(10,11,12);
     expect(triangle.kind()).toEqual("scalene");
   });
 
-  xit("scalene triangles have no equal sides in descending order either", function() {
+  it("scalene triangles have no equal sides in descending order either", function() {
     var triangle = new Triangle(5,4,2);
     expect(triangle.kind()).toEqual("scalene");
   });
 
-  xit("very small triangles are legal", function() {
+  it("very small triangles are legal", function() {
     var triangle = new Triangle(0.4,0.6,0.3);
     expect(triangle.kind()).toEqual("scalene");
   });
 
-  xit("test triangles with no size are illegal", function() {
+  it("test triangles with no size are illegal", function() {
     var triangle = new Triangle(0,0,0);
-    expect(triangle.kind).toThrow();
+    expect(triangle.kind.bind(triangle)).toThrow();
   });
 
-  xit("triangles with negative sides are illegal", function() {
+  it("triangles with negative sides are illegal", function() {
     var triangle = new Triangle(3,4,-5);
-    expect(triangle.kind()).toEqual("illegal");
+    expect(triangle.kind.bind(triangle)).toThrow();
   });
 
-  xit("triangles violating triangle inequality are illegal", function() {
+  it("triangles violating triangle inequality are illegal", function() {
     var triangle = new Triangle(1,1,3);
-    expect(triangle.kind()).toEqual("illegal");
+    expect(triangle.kind.bind(triangle)).toThrow();
   });
 
-  xit("triangles violating triangle inequality are illegal 2", function() {
+  it("triangles violating triangle inequality are illegal 2", function() {
     var triangle = new Triangle(2,4,2);
-    expect(triangle.kind()).toEqual("illegal");
+    expect(triangle.kind.bind(triangle)).toThrow();
   });
 
-  xit("triangles violating triangle inequality are illegal 3", function() {
+  it("triangles violating triangle inequality are illegal 3", function() {
     var triangle = new Triangle(7,3,2);
-    expect(triangle.kind()).toEqual("illegal");
+    expect(triangle.kind.bind(triangle)).toThrow();
   });
 
 });


### PR DESCRIPTION
The example should throw when `illegal` instead of setting a string. The entire example could use some refactoring, but this should be good enough for now.

Was not sure if we should continue with skipping all but first test so I went ahead and left them all un-skipped. I can change that if we aren't ready to go down that road yet.
