### PR TITLE
correct # of random chars and fix test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # assignments
 ASSIGNMENT ?= ""
 IGNOREDIRS := "^(\.git|bin|node_modules)$$"
-ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d -exec basename -a {} + | sort | grep -Ev $(IGNOREDIRS))
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | xargs basename | sort | grep -Ev $(IGNOREDIRS))
 
 # output directories
 TMPDIR ?= "/tmp"

--- a/robot-name/example.js
+++ b/robot-name/example.js
@@ -2,7 +2,7 @@ function Robot() {
   'use strict';
 
   this.generateName = function() {
-    return this.generateRandomChars(3) + this.generateRandomNumbers(3);
+    return this.generateRandomChars(2) + this.generateRandomNumbers(3);
   };
 
   this.generateRandomChars = function(count) {
@@ -30,7 +30,7 @@ function Robot() {
   this.name = this.generateName();
 
   this.reset = function() {
-    this.name = "ABC123";
+    this.name = null;
   };
 }
 

--- a/robot-name/robot-name_test.spec.js
+++ b/robot-name/robot-name_test.spec.js
@@ -6,18 +6,18 @@ describe("Robot", function() {
     expect(robot.name).toMatch(/^[A-Z]{2}\d{3}$/);
   });
 
-  xit("name is the same each time", function() {
+  it("name is the same each time", function() {
     var robot = new Robot();
     expect(robot.name).toEqual(robot.name);
   });
 
-  xit("different robots have different names", function() {
+  it("different robots have different names", function() {
     var robotOne = new Robot();
     var robotTwo = new Robot();
     expect(robotOne.name).not.toEqual(robotTwo.name);
   });
 
-  xit("is able to reset the name", function() {
+  it("is able to reset the name", function() {
     var robot = new Robot();
     var originalName = robot.name;
     robot.reset();


### PR DESCRIPTION
The last PR fixed the regex; however, that fix broke the tests since the # of characters generated was incorrect. Travis did not catch it because something changed on the Travis side such that `basename -a` no longer works. I changed the `Makefile` to not use that technique (it was a premature optimization anyhow) and instead use `xargs basename`. Oddly enough, Travis did not break when `basename -a` failed. It failed silently in that the process still ended with a status of 0.

Let's see if Travis likes this rendition.
