### PR TITLE
Readme and clojure tests agree about 5 char ciphertext

### DIFF
--- a/crypto-square/crypto-square_test.spec.js
+++ b/crypto-square/crypto-square_test.spec.js
@@ -48,7 +48,7 @@ describe("Crypto",function() {
 
   xit("normalized cipher text",function() {
     var crypto = new Crypto('Madness, and then illumination.');
-    expect(crypto.normalizeCiphertext()).toEqual('msemoa anindn inndla etltsh ui');
+    expect(crypto.normalizeCiphertext()).toEqual('msemo aanin dninn dlaet ltshu i');
   });
 
   xit("more normalized cipher text",function() {


### PR DESCRIPTION
The current test splits the cipher-text into 6 character bins (actually probably the ceil(sqrt(len))) for this test, the read-me and the Clojure exercises split it into 5 character bins no matter the length of input.
