### PR TITLE
correctly compute hamming for strands of unequal length

### DIFF
--- a/hamming/example.js
+++ b/hamming/example.js
@@ -1,7 +1,14 @@
 exports.compute = function (strand1, strand2) {
+  var len1 = strand1.length;
+  var len2 = strand2.length;
+
+  if (len1 !== len2) {
+    throw new Error('DNA strands must be of equal length.');
+  }
+
   var out = -0;
   var idx = -1;
-  var end = Math.min(strand1.length, strand2.length);
+  var end = Math.max(len1, len2);
 
   while (++idx < end) {
     if (strand1[idx] !== strand2[idx]) out++;

--- a/hamming/hamming_test.spec.js
+++ b/hamming/hamming_test.spec.js
@@ -30,5 +30,10 @@ describe('Hamming', function () {
     expect(compute('GGACGGATTCTG', 'AGGACGGATTCT')).toEqual(9);
   });
 
-});
+  xit('throws error when strands are not equal length', function() {
+    expect(function() { compute('GGACGGATTCTG', 'AGGAC'); }).toThrow(
+      new Error('DNA strands must be of equal length.')
+    );
+  });
 
+});


### PR DESCRIPTION
Since the hamming distance is equal to the difference between two homologous DNA strands I wanted to add a test that checked the solution was properly limiting the upper bound of the point comparisons.

This cropped up in a nitpick for code like this

`var len = Math.min(strand1.length, strand2.length);`

which suggested the use of `Math.max()` over `Math.min()`. With the present test suite,`Math.max()` makes all the tests pass, but it inflates the hamming distance because it includes point comparisons that should not be included.

Any thoughts?
